### PR TITLE
only use major version to specify python version

### DIFF
--- a/src/batchjudge.cpp
+++ b/src/batchjudge.cpp
@@ -52,9 +52,9 @@ int BatchJudge(int pid, int td, int boxid, int tl, int ml, int ol, int testee,
 
   // invoke box command
   if (lang == "python2") {
-    sandboxExec(boxid, opt, {"/usr/bin/env", "python2.7", "main.pyc"});
+    sandboxExec(boxid, opt, {"/usr/bin/env", "python2", "main.pyc"});
   } else if (lang == "python3") {
-    sandboxExec(boxid, opt, {"/usr/bin/env", "python3.7", "main.pyc"});
+    sandboxExec(boxid, opt, {"/usr/bin/env", "python3", "main.pyc"});
   } else {
     sandboxExec(boxid, opt, {"main.out"});
   }

--- a/src/batchjudge.cpp
+++ b/src/batchjudge.cpp
@@ -12,7 +12,7 @@ int BatchJudge(int pid, int td, int boxid, int tl, int ml, int ol, int testee,
   cerr << nounitbuf;
 
   string target;
-  if (lang == "python2" || lang == "python3") {
+  if (lang.find_first_of("python") == 0) {
     target = "main.pyc";
   } else {
     target = "main.out";
@@ -45,16 +45,10 @@ int BatchJudge(int pid, int td, int boxid, int tl, int ml, int ol, int testee,
   opt.fsize_limit = ol;
   opt.envs.push_back(string("PATH=") + getenv("PATH"));
   opt.file_limit = 48;
-  if (lang == "python2" || lang == "python3") {
+  if (lang.find_first_of("python") == 0) {
     opt.envs.push_back("HOME=" + BoxPath(boxid));
     opt.envs.push_back("PYTHONIOENCODING=utf-8");
-  }
-
-  // invoke box command
-  if (lang == "python2") {
-    sandboxExec(boxid, opt, {"/usr/bin/env", "python2", "main.pyc"});
-  } else if (lang == "python3") {
-    sandboxExec(boxid, opt, {"/usr/bin/env", "python3", "main.pyc"});
+    sandboxExec(boxid, opt, {"/usr/bin/env", std::move(lang), "main.pyc"});
   } else {
     sandboxExec(boxid, opt, {"main.out"});
   }

--- a/src/testsuite.cpp
+++ b/src/testsuite.cpp
@@ -243,7 +243,7 @@ int compile(const submission& target, int boxid, int spBoxid) {
     fout.open(boxdir + "main.c");
   } else if (target.lang == "haskell") {
     fout.open(boxdir + "main.hs");
-  } else if (target.lang == "python2" || target.lang == "python3") {
+  } else if (target.lang.find_first_of("python") == 0) {
     fout.open(boxdir + "main.py");
   } else {
     return CE;
@@ -295,7 +295,7 @@ int compile(const submission& target, int boxid, int spBoxid) {
 
   sandboxExec(boxid, opt, args);
   string compiled_target;
-  if (target.lang == "python2" || target.lang == "python3")
+  if (target.lang.find_first_of("python") == 0)
     compiled_target = "main.pyc";
   else
     compiled_target = "main.out";

--- a/src/testsuite.cpp
+++ b/src/testsuite.cpp
@@ -273,9 +273,9 @@ int compile(const submission& target, int boxid, int spBoxid) {
     args = {"/usr/bin/env", "ghc",     "./main.hs", "-o", "./main.out",
             "-O",           "-tmpdir", ".",         "-w"};
   } else if (target.lang == "python2") {
-    args = {"/usr/bin/env", "python2.7", "-m", "py_compile", "main.py"};
+    args = {"/usr/bin/env", "python2", "-m", "py_compile", "main.py"};
   } else if (target.lang == "python3") {
-    args = {"/usr/bin/env", "python3.7", "-c",
+    args = {"/usr/bin/env", "python3", "-c",
             "import py_compile;py_compile.compile(\'main.py\',\'main.pyc\')"};
   }
   if (!target.std.empty() && target.std != "c90") {


### PR DESCRIPTION
I think it is more flexible to use only major version of python. Also, miku seems only check the major version of python, so it might not be necessary to specify minor version in the code.